### PR TITLE
Make IntVector et al's dtors non-virtual.

### DIFF
--- a/source/hierarchy/boxes/Index.I
+++ b/source/hierarchy/boxes/Index.I
@@ -66,11 +66,6 @@ Index<DIM>& Index<DIM>::operator=(const IntVector<DIM>& rhs)
 }
 
 template<int DIM> inline
-Index<DIM>::~Index()
-{
-}
-
-template<int DIM> inline
 Index<DIM>& Index<DIM>::operator+=(const IntVector<DIM>& rhs)
 {
    IntVector<DIM>::operator+=(rhs);

--- a/source/hierarchy/boxes/Index.h
+++ b/source/hierarchy/boxes/Index.h
@@ -86,11 +86,6 @@ public:
    Index<DIM>& operator=(const IntVector<DIM>& rhs);
 
    /**
-    * The index destructor does nothing interesting.
-    */
-   ~Index();
-
-   /**
     * Plus-equals operator for an index and an integer vector.
     */
    Index<DIM>& operator+=(const IntVector<DIM>& rhs);

--- a/source/hierarchy/boxes/IntVector.I
+++ b/source/hierarchy/boxes/IntVector.I
@@ -94,11 +94,6 @@ IntVector<DIM>& IntVector<DIM>::operator=(const IntVector<DIM>& rhs)
 }
 
 template<int DIM> inline
-IntVector<DIM>::~IntVector()
-{
-}
-
-template<int DIM> inline
 int& IntVector<DIM>::operator()(const int i)
 {
    

--- a/source/hierarchy/boxes/IntVector.h
+++ b/source/hierarchy/boxes/IntVector.h
@@ -72,11 +72,6 @@ public:
    IntVector& operator=(const IntVector<DIM>& rhs);
 
    /**
-    * The integer vector destructor does nothing interesting.
-    */
-   virtual ~IntVector();
-
-   /**
     * Return the specified component of the vector.  No bounds checking.
     */
    int& operator()(const int i);

--- a/source/patchdata/cell/CellIndex.I
+++ b/source/patchdata/cell/CellIndex.I
@@ -36,11 +36,6 @@ CellIndex<DIM>& CellIndex<DIM>::operator=(const CellIndex<DIM>& rhs)
 }
 
 template<int DIM> inline
-CellIndex<DIM>::~CellIndex()
-{
-}
-
-template<int DIM> inline
 CellIndex<DIM>& CellIndex<DIM>::operator+=(const hier::IntVector<DIM>& rhs)
 {
    hier::Index<DIM>::operator+=(rhs);

--- a/source/patchdata/cell/CellIndex.h
+++ b/source/patchdata/cell/CellIndex.h
@@ -52,11 +52,6 @@ public:
    CellIndex<DIM>& operator=(const CellIndex<DIM>& rhs);
 
    /**
-    * The cell index destructor does nothing interesting.
-    */
-   ~CellIndex();
-
-   /**
     * Plus-equals operator for a cell index and an integer vector.
     */
    CellIndex<DIM>& operator+=(const hier::IntVector<DIM>& rhs);

--- a/source/patchdata/edge/EdgeIndex.I
+++ b/source/patchdata/edge/EdgeIndex.I
@@ -51,11 +51,6 @@ EdgeIndex<DIM>& EdgeIndex<DIM>::operator=(const EdgeIndex<DIM>& rhs)
 }
 
 template<int DIM> inline
-EdgeIndex<DIM>::~EdgeIndex()
-{
-}
-
-template<int DIM> inline
 int EdgeIndex<DIM>::getAxis() const
 {
    return(d_axis);

--- a/source/patchdata/edge/EdgeIndex.h
+++ b/source/patchdata/edge/EdgeIndex.h
@@ -58,11 +58,6 @@ public:
    EdgeIndex<DIM>& operator=(const EdgeIndex<DIM>& rhs);
 
    /**
-    * The edge index destructor does nothing interesting.
-    */
-   ~EdgeIndex();
-
-   /**
     * Get the axis for which this edge index is defined (X=0, Y=1, Z=2).
     */
    int getAxis() const;

--- a/source/patchdata/face/FaceIndex.I
+++ b/source/patchdata/face/FaceIndex.I
@@ -45,11 +45,6 @@ FaceIndex<DIM>& FaceIndex<DIM>::operator=(const FaceIndex<DIM>& rhs)
 }
 
 template<int DIM> inline
-FaceIndex<DIM>::~FaceIndex()
-{
-}
-
-template<int DIM> inline
 int FaceIndex<DIM>::getAxis() const
 {
    return(d_axis);

--- a/source/patchdata/face/FaceIndex.h
+++ b/source/patchdata/face/FaceIndex.h
@@ -57,11 +57,6 @@ public:
    FaceIndex<DIM>& operator=(const FaceIndex<DIM>& rhs);
 
    /**
-    * The face index destructor does nothing interesting.
-    */
-   ~FaceIndex();
-
-   /**
     * Get the axis for which this face index is defined (X=0, Y=1, Z=2).
     */
    int getAxis() const;

--- a/source/patchdata/node/NodeIndex.I
+++ b/source/patchdata/node/NodeIndex.I
@@ -58,11 +58,6 @@ NodeIndex<DIM>& NodeIndex<DIM>::operator=(const NodeIndex<DIM>& rhs)
 }
 
 template<int DIM> inline
-NodeIndex<DIM>::~NodeIndex()
-{
-}
-
-template<int DIM> inline
 NodeIndex<DIM>& NodeIndex<DIM>::operator+=(const hier::IntVector<DIM>& rhs)
 {
    hier::Index<DIM>::operator+=(rhs);

--- a/source/patchdata/node/NodeIndex.h
+++ b/source/patchdata/node/NodeIndex.h
@@ -83,11 +83,6 @@ public:
    NodeIndex<DIM>& operator=(const NodeIndex<DIM>& rhs);
 
    /**
-    * The node index destructor does nothing interesting.
-    */
-   ~NodeIndex();
-
-   /**
     * Plus-equals operator for a node index and an integer vector.
     */
    NodeIndex<DIM>& operator+=(const hier::IntVector<DIM>& rhs);

--- a/source/patchdata/side/SideIndex.I
+++ b/source/patchdata/side/SideIndex.I
@@ -47,11 +47,6 @@ SideIndex<DIM>& SideIndex<DIM>::operator=(const SideIndex<DIM>& rhs)
 }
 
 template<int DIM> inline
-SideIndex<DIM>::~SideIndex()
-{
-}
-
-template<int DIM> inline
 int SideIndex<DIM>::getAxis() const
 {
    return(d_axis);

--- a/source/patchdata/side/SideIndex.h
+++ b/source/patchdata/side/SideIndex.h
@@ -57,11 +57,6 @@ public:
    SideIndex<DIM>& operator=(const SideIndex<DIM>& rhs);
 
    /**
-    * The side index destructor does nothing interesting.
-    */
-   ~SideIndex();
-
-   /**
     * Get the axis for which this side index is defined (X=0, Y=1, Z=2).
     */
    int getAxis() const;


### PR DESCRIPTION
There's just no reason to do this and storing the vtable pointer makes these objects twice as large as they need to be.