### PR TITLE
Fix execution with modern versions of HDF5.

### DIFF
--- a/source/toolbox/base/SAMRAIManager.C
+++ b/source/toolbox/base/SAMRAIManager.C
@@ -15,6 +15,10 @@
 #include "tbox/MathUtilities.h"
 #include "tbox/Utilities.h"
 
+#ifdef HAVE_HDF5
+#include "hdf5.h"
+#endif
+
 #include <new>
 
 namespace SAMRAI {
@@ -66,6 +70,19 @@ static void badnew()
 
 void SAMRAIManager::startup()
 {
+#if HAVE_HDF5
+   // Modern versions of HDF5 detect the floating-point environment by
+   // performing several operations which trigger floating-point exceptions.
+   // Hence we need to set up HDF5's global state before calling the IEEE::
+   // functions which set up those exceptions.
+   const int ierr = H5open();
+   if (ierr < 0)
+   {
+      TBOX_ERROR("SAMRAIManager::startup() error..." << std::endl
+                 << "Unable to start HDF5: failed with error code " << ierr << std::endl);
+   }
+#endif
+
    SAMRAI_MPI::initialize();
    PIO::initialize();
    IEEE::setupFloatingPointExceptionHandlers();


### PR DESCRIPTION
New versions of HDF5 empirically determine the floating-point environment by dividing by zero and doing other things which may raise floating point exceptions - this is incompatible with SAMRAI, which always checks for floating point exceptions.

We might want to disable that behavior. However, for now, we can get around that by simply initializing HDF5 ourselves before setting up SIGFPE signals.