### PR TITLE
Remove some redundant template specifiers.

### DIFF
--- a/source/hierarchy/multiblock/MBUtilities.h
+++ b/source/hierarchy/multiblock/MBUtilities.h
@@ -31,7 +31,7 @@ public:
    /*!
     * Constructor
     */
-   MBUtilities<DIM>();
+   MBUtilities();
 
    /*!
     * Virtual destructor does nothing

--- a/source/hierarchy/patches/CoarseFineBoundary.h
+++ b/source/hierarchy/patches/CoarseFineBoundary.h
@@ -72,7 +72,7 @@ public:
     *
     * Note that if level number is zero, the coarse-fine boundary will be empty.
     */
-   CoarseFineBoundary<DIM>(
+   CoarseFineBoundary(
       const PatchHierarchy<DIM>& hierarchy,
       int ln,
       const IntVector<DIM>& max_ghost_width);
@@ -97,7 +97,7 @@ public:
     *
     * Note that if level number is zero, the coarse-fine boundary will be empty.
     */
-   CoarseFineBoundary<DIM>(
+   CoarseFineBoundary(
       const tbox::Pointer< MultiblockPatchHierarchy<DIM> >& hierarchy,
       int ln,
       const IntVector<DIM>& max_ghost_width);

--- a/source/patchdata/boxgeometry/OuteredgeGeometry.h
+++ b/source/patchdata/boxgeometry/OuteredgeGeometry.h
@@ -118,7 +118,7 @@ private:
       const bool overwrite_interior,
       const hier::IntVector<DIM>& src_offset);
 
-   OuteredgeGeometry<DIM>(const OuteredgeGeometry<DIM>&);// not implemented
+   OuteredgeGeometry(const OuteredgeGeometry<DIM>&);// not implemented
    void operator=(const OuteredgeGeometry<DIM>&);	// not implemented
 
    hier::Box<DIM> d_box;

--- a/source/patchdata/index/IndexData.h
+++ b/source/patchdata/index/IndexData.h
@@ -381,9 +381,9 @@ public:
    friend class IndexIterator<DIM,TYPE,BOX_GEOMETRY>;
    friend class ConstIndexIterator<DIM,TYPE,BOX_GEOMETRY>;
 
-   IndexDataNode<DIM,TYPE,BOX_GEOMETRY>();
+   IndexDataNode();
 
-   IndexDataNode<DIM,TYPE,BOX_GEOMETRY>(
+   IndexDataNode(
       const hier::Index<DIM>& index,
       const int d_offset,
       TYPE& t,

--- a/source/patchdata/multiblock/MultiblockCellDataTranslator.h
+++ b/source/patchdata/multiblock/MultiblockCellDataTranslator.h
@@ -28,7 +28,7 @@ public:
    /*!
     * @brief Constructor
     */
-   MultiblockCellDataTranslator<DIM,TYPE>(); 
+   MultiblockCellDataTranslator();
 
    /*!
     * @brief The virtual destructor does nothing interesting.

--- a/source/patchdata/multiblock/MultiblockEdgeDataTranslator.h
+++ b/source/patchdata/multiblock/MultiblockEdgeDataTranslator.h
@@ -29,7 +29,7 @@ public:
    /*!
     * @brief Constructor
     */
-   MultiblockEdgeDataTranslator<DIM,TYPE>(); 
+   MultiblockEdgeDataTranslator();
 
    /*!
     * @brief The virtual destructor does nothing interesting.

--- a/source/patchdata/multiblock/MultiblockFaceDataTranslator.h
+++ b/source/patchdata/multiblock/MultiblockFaceDataTranslator.h
@@ -29,7 +29,7 @@ public:
    /*!
     * @brief Constructor
     */
-   MultiblockFaceDataTranslator<DIM,TYPE>(); 
+   MultiblockFaceDataTranslator();
 
    /*!
     * @brief The virtual destructor does nothing interesting.

--- a/source/patchdata/multiblock/MultiblockNodeDataTranslator.h
+++ b/source/patchdata/multiblock/MultiblockNodeDataTranslator.h
@@ -28,7 +28,7 @@ public:
    /*!
     * @brief Constructor
     */
-   MultiblockNodeDataTranslator<DIM,TYPE>(); 
+   MultiblockNodeDataTranslator();
 
    /*!
     * @brief The virtual destructor does nothing interesting.

--- a/source/patchdata/multiblock/MultiblockSideDataTranslator.h
+++ b/source/patchdata/multiblock/MultiblockSideDataTranslator.h
@@ -29,7 +29,7 @@ public:
    /*!
     * @brief Constructor
     */
-   MultiblockSideDataTranslator<DIM,TYPE>(); 
+   MultiblockSideDataTranslator();
 
    /*!
     * @brief The virtual destructor does nothing interesting.

--- a/source/patchdata/outeredge/OuteredgeData.h
+++ b/source/patchdata/outeredge/OuteredgeData.h
@@ -558,7 +558,7 @@ public:
         tbox::Pointer<tbox::Database> database); 
 
 private:
-   OuteredgeData<DIM,TYPE>(const OuteredgeData<DIM,TYPE>&); // not implemented
+   OuteredgeData(const OuteredgeData<DIM,TYPE>&); // not implemented
    void operator=(const OuteredgeData<DIM,TYPE>&);	  // not implemented
 
    //@{

--- a/source/patchdata/outernode/OuternodeData.h
+++ b/source/patchdata/outernode/OuternodeData.h
@@ -507,7 +507,7 @@ public:
         tbox::Pointer<tbox::Database> database); 
 
 private:
-   OuternodeData<DIM,TYPE>(const OuternodeData<DIM,TYPE>&); // not implemented
+   OuternodeData(const OuternodeData<DIM,TYPE>&); // not implemented
    void operator=(const OuternodeData<DIM,TYPE>&);	  // not implemented
 
    //@

--- a/source/patchdata/outernode/OuternodeVariable.h
+++ b/source/patchdata/outernode/OuternodeVariable.h
@@ -71,7 +71,7 @@ public:
 
 private:
    // neither of the following functions are implemented
-   OuternodeVariable<DIM,TYPE>(const OuternodeVariable<DIM,TYPE>&);
+   OuternodeVariable(const OuternodeVariable<DIM,TYPE>&);
    void operator=(const OuternodeVariable<DIM,TYPE>&);
 
 };


### PR DESCRIPTION
This is no longer permitted in C++20 and GCC-14 warns about it.