### PR TITLE
Fix a function type.

### DIFF
--- a/source/toolbox/base/ParallelBuffer.C
+++ b/source/toolbox/base/ParallelBuffer.C
@@ -289,14 +289,12 @@ int ParallelBuffer::sync()
 *************************************************************************
 */
 
-#if !defined(__INTEL_COMPILER) && (defined(__GNUG__))
-std::streamsize ParallelBuffer::xsputn(const std::string &text, std::streamsize n)
+std::streamsize ParallelBuffer::xsputn(const char * text, std::streamsize n)
 {
    sync();
    if (n > 0) outputString(text, n);
    return(n);
 }
-#endif
 
 /*
 *************************************************************************

--- a/source/toolbox/base/ParallelBuffer.h
+++ b/source/toolbox/base/ParallelBuffer.h
@@ -91,13 +91,11 @@ public:
     */
    virtual int sync();
 
-#if !defined(__INTEL_COMPILER) && (defined(__GNUG__))
    /**
     * Write the specified number of characters into the output stream (called
     * from streambuf).
     */
-   virtual std::streamsize xsputn (const std::string &text, std::streamsize n);
-#endif
+   virtual std::streamsize xsputn (const char * text, std::streamsize n);
 
    /**
     * Write an overflow character into the parallel buffer (called from


### PR DESCRIPTION
This mistake is really fascinating because xsputn() is one of the oldest functions in C++ - I think it even predates std::string. This has been wrong since the mid 1980s.