### PR TITLE
Add a lot more timers.

### DIFF
--- a/source/algorithm/femutils/standard/OuteredgeSumTransaction.C
+++ b/source/algorithm/femutils/standard/OuteredgeSumTransaction.C
@@ -18,6 +18,7 @@
 #include "EdgeGeometry.h"
 #include "OuteredgeData.h"
 #include "tbox/SAMRAI_MPI.h"
+#include "tbox/TimerManager.h"
 
 namespace SAMRAI {
     namespace algs {
@@ -162,6 +163,7 @@ OuteredgeSumTransaction<DIM>::getDestinationProcessor()
 template<int DIM> void 
 OuteredgeSumTransaction<DIM>::packStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("algs::OuteredgeSumTransaction::packStream()");
    d_src_level->getPatch(d_src_patch)
               ->getPatchData(s_refine_items[d_refine_item_id]->
                              d_src)
@@ -171,6 +173,7 @@ OuteredgeSumTransaction<DIM>::packStream(tbox::AbstractStream& stream)
 template<int DIM> void 
 OuteredgeSumTransaction<DIM>::unpackStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("algs::OuteredgeSumTransaction::unpackStream()");
    tbox::Pointer<pdat::OuteredgeData<DIM,double> > oedge_dst_data = 
       d_dst_level->getPatch(d_dst_patch)->
          getPatchData(s_refine_items[d_refine_item_id]->d_scratch);

--- a/source/algorithm/femutils/standard/OuternodeSumTransaction.C
+++ b/source/algorithm/femutils/standard/OuternodeSumTransaction.C
@@ -18,6 +18,7 @@
 #include "NodeGeometry.h"
 #include "OuternodeData.h"
 #include "tbox/SAMRAI_MPI.h"
+#include "tbox/TimerManager.h"
 
 namespace SAMRAI {
     namespace algs {
@@ -161,6 +162,7 @@ OuternodeSumTransaction<DIM>::getDestinationProcessor()
 template<int DIM> void 
 OuternodeSumTransaction<DIM>::packStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("algs::OuternodeSumTransaction::packStream()");
    d_src_level->getPatch(d_src_patch)
               ->getPatchData(s_refine_items[d_refine_item_id]->
                              d_src)
@@ -170,6 +172,7 @@ OuternodeSumTransaction<DIM>::packStream(tbox::AbstractStream& stream)
 template<int DIM> void 
 OuternodeSumTransaction<DIM>::unpackStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("algs::OuternodeSumTransaction::unpackStream()");
    tbox::Pointer< pdat::OuternodeData<DIM,double> > onode_dst_data =
       d_dst_level->getPatch(d_dst_patch)->
          getPatchData(s_refine_items[d_refine_item_id]->d_scratch);
@@ -181,6 +184,7 @@ OuternodeSumTransaction<DIM>::unpackStream(tbox::AbstractStream& stream)
 template<int DIM> void 
 OuternodeSumTransaction<DIM>::copyLocalData()
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("algs::OuternodeSumTransaction::copyLocalData()");
    tbox::Pointer< pdat::OuternodeData<DIM,double> > onode_dst_data =
       d_dst_level->getPatch(d_dst_patch)->
          getPatchData(s_refine_items[d_refine_item_id]->d_scratch);

--- a/source/patchdata/array/ArrayData.C
+++ b/source/patchdata/array/ArrayData.C
@@ -20,6 +20,7 @@
 #include "ArrayDataOperationUtilities.h"
 #include "CopyOperation.h"
 #include "SumOperation.h"
+#include "tbox/TimerManager.h"
 
 
 #define PDAT_ARRAYDATA_VERSION 1
@@ -61,6 +62,7 @@ void MessageStream::packArrayData(const pdat::ArrayData<DIM,TYPE>& arraydata,
                                   const hier::Box<DIM>& dest_box,
                                   const hier::IntVector<DIM>& src_shift)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::MessageStream::packArrayData()");
    int n_items = arraydata.getDepth() * dest_box.size();
    int n_bytes = abstract_stream_sizeof<TYPE>(n_items);
    TYPE* dst_buffer = static_cast<TYPE*>(getPointerAndAdvanceCursor(n_bytes));
@@ -87,6 +89,7 @@ void MessageStream::unpackArrayData(pdat::ArrayData<DIM,TYPE>& arraydata,
                                     const hier::Box<DIM>& dest_box,
                                     const hier::IntVector<DIM>& /*src_shift*/)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::MessageStream::unpackArrayData()");
    int n_items = arraydata.getDepth() * dest_box.size();
    int n_bytes = abstract_stream_sizeof<TYPE>(n_items);
    TYPE* src_buffer = static_cast<TYPE*>(getPointerAndAdvanceCursor(n_bytes));
@@ -112,6 +115,7 @@ void MessageStream::unpackAndSumArrayData(pdat::ArrayData<DIM,TYPE>& arraydata,
                                           const hier::Box<DIM>& dest_box,
                                           const hier::IntVector<DIM>& /*src_shift*/)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::MessageStream::unpackAndSumArrayData()");
    int n_items = arraydata.getDepth() * dest_box.size();
    int n_bytes = abstract_stream_sizeof<TYPE>(n_items);
    TYPE* src_buffer = static_cast<TYPE*>(getPointerAndAdvanceCursor(n_bytes));
@@ -580,6 +584,7 @@ void ArrayData<DIM,TYPE>::packStream(
    const hier::Box<DIM>& dest_box,
    const hier::IntVector<DIM>& src_shift) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::ArrayData::packStream()[dest_box]");
 
    tbox::MessageStream* stream_ptr = dynamic_cast<tbox::MessageStream*>(&stream);
    if (stream_ptr)
@@ -606,6 +611,7 @@ void ArrayData<DIM,TYPE>::packStream(
    const hier::BoxList<DIM>& dest_boxes,
    const hier::IntVector<DIM>& src_shift) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::ArrayData::packStream()[dest_boxes]");
 
    tbox::MessageStream* stream_ptr = dynamic_cast<tbox::MessageStream*>(&stream);
    if (stream_ptr)
@@ -652,6 +658,7 @@ void ArrayData<DIM,TYPE>::unpackStream(
    const hier::Box<DIM>& dest_box,
    const hier::IntVector<DIM>& src_shift)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::ArrayData::unpackStream()[dest_box]");
 
    tbox::MessageStream* stream_ptr = dynamic_cast<tbox::MessageStream*>(&stream);
    if (stream_ptr)
@@ -676,6 +683,7 @@ void ArrayData<DIM,TYPE>::unpackStream(
    const hier::BoxList<DIM>& dest_boxes,
    const hier::IntVector<DIM>& src_shift)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::ArrayData::unpackStream()[dest_boxes]");
 
    tbox::MessageStream* stream_ptr = dynamic_cast<tbox::MessageStream*>(&stream);
    if (stream_ptr)
@@ -722,6 +730,7 @@ void ArrayData<DIM,TYPE>::unpackStreamAndSum(
    const hier::Box<DIM>& dest_box,
    const hier::IntVector<DIM>& src_shift)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::ArrayData::unpackStreamAndSum()[dest_box]");
 
    tbox::MessageStream* stream_ptr = dynamic_cast<tbox::MessageStream*>(&stream);
    if (stream_ptr)
@@ -746,6 +755,7 @@ void ArrayData<DIM,TYPE>::unpackStreamAndSum(
    const hier::BoxList<DIM>& dest_boxes,
    const hier::IntVector<DIM>& src_shift)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("tbox::ArrayData::unpackStreamAndSum()[dest_boxes]");
 
    tbox::MessageStream* stream_ptr = dynamic_cast<tbox::MessageStream*>(&stream);
    if (stream_ptr)

--- a/source/patchdata/array/ArrayDataOperationUtilities.C
+++ b/source/patchdata/array/ArrayDataOperationUtilities.C
@@ -16,6 +16,8 @@
 #include "tbox/Utilities.h"
 #endif
 
+#include "tbox/TimerManager.h"
+
 namespace SAMRAI {
     namespace pdat {
 
@@ -40,6 +42,7 @@ void ArrayDataOperationUtilities<DIM, TYPE, OP>::doArrayDataOperationOnBox(
    int num_depth,
    const OP& op)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::ArrayDataOperationUtilities::doArrayDataOperationOnBox()");
 #ifdef DEBUG_CHECK_ASSERTIONS
    TBOX_ASSERT(num_depth >= 0);
    TBOX_ASSERT( (0 <= dst_start_depth) && (dst_start_depth + num_depth <= dst.getDepth()) );
@@ -172,6 +175,7 @@ void ArrayDataOperationUtilities<DIM, TYPE, OP>::doArrayDataBufferOperationOnBox
    bool src_is_buffer,
    const OP& op)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::ArrayDataOperationUtilities::doArrayDataBufferOperationOnBox()");
 #ifdef DEBUG_CHECK_ASSERTIONS
    TBOX_ASSERT( buffer != (const TYPE*)NULL );
    TBOX_ASSERT( opbox == (opbox * arraydata.getBox()) );

--- a/source/patchdata/cell/CellData.C
+++ b/source/patchdata/cell/CellData.C
@@ -19,6 +19,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 
 #define PDAT_CELLDATA_VERSION 1
 
@@ -249,6 +250,7 @@ template<int DIM, class TYPE>
 void CellData<DIM,TYPE>::packStream(
    tbox::AbstractStream& stream, const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::CellData::packStream()");
    const CellOverlap<DIM> *t_overlap = 
       dynamic_cast<const CellOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -262,6 +264,7 @@ template<int DIM, class TYPE>
 void CellData<DIM,TYPE>::unpackStream(
    tbox::AbstractStream& stream, const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::CellData::unpackStream()");
    const CellOverlap<DIM> *t_overlap = 
       dynamic_cast<const CellOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/patchdata/edge/EdgeData.C
+++ b/source/patchdata/edge/EdgeData.C
@@ -19,6 +19,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 
 #define PDAT_EDGEDATA_VERSION 1
 
@@ -250,6 +251,7 @@ template<int DIM, class TYPE>
 void EdgeData<DIM,TYPE>::packStream(tbox::AbstractStream& stream,
                                       const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::EdgeData::packStream()");
    const EdgeOverlap<DIM> *t_overlap =
       dynamic_cast<const EdgeOverlap<DIM> *>(&overlap);
 
@@ -270,6 +272,7 @@ template<int DIM, class TYPE>
 void EdgeData<DIM,TYPE>::unpackStream(tbox::AbstractStream& stream,
                                       const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::EdgeData::unpackStream()");
    const EdgeOverlap<DIM> *t_overlap =
       dynamic_cast<const EdgeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/patchdata/face/FaceData.C
+++ b/source/patchdata/face/FaceData.C
@@ -20,6 +20,7 @@
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
 #include <stdio.h>
+#include "tbox/TimerManager.h"
 
 #define PDAT_FACEDATA_VERSION 1
 
@@ -268,6 +269,7 @@ template<int DIM, class TYPE>
 void FaceData<DIM,TYPE>::packStream(tbox::AbstractStream& stream,
                                     const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::FaceData::packStream()");
    const FaceOverlap<DIM> *t_overlap =
       dynamic_cast<const FaceOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -293,6 +295,7 @@ template<int DIM, class TYPE>
 void FaceData<DIM,TYPE>::unpackStream(tbox::AbstractStream& stream,
                                       const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::FaceData::unpackStream()");
    const FaceOverlap<DIM> *t_overlap =
       dynamic_cast<const FaceOverlap<DIM> *>(&overlap);
 

--- a/source/patchdata/index/IndexData.C
+++ b/source/patchdata/index/IndexData.C
@@ -17,6 +17,7 @@
 #include "BoxOverlap.h"
 #include "tbox/Utilities.h"
 #include "tbox/IOStream.h"
+#include "tbox/TimerManager.h"
 
 #define PDAT_INDEXDATA_VERSION 1
 
@@ -219,6 +220,7 @@ void IndexData<DIM,TYPE,BOX_GEOMETRY>::packStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::IndexData::packStream()");
    const typename BOX_GEOMETRY::Overlap *t_overlap =
       dynamic_cast<const typename BOX_GEOMETRY::Overlap *>(&overlap);
    TBOX_CHECK_ASSERT(t_overlap != NULL);
@@ -262,6 +264,7 @@ void IndexData<DIM,TYPE,BOX_GEOMETRY>::unpackStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::IndexData::unpackStream()");
    const typename BOX_GEOMETRY::Overlap *t_overlap =
       dynamic_cast<const typename BOX_GEOMETRY::Overlap *>(&overlap);
    TBOX_CHECK_ASSERT(t_overlap != NULL);

--- a/source/patchdata/node/NodeData.C
+++ b/source/patchdata/node/NodeData.C
@@ -18,6 +18,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 
 #define PDAT_NODEDATA_VERSION 1
 
@@ -227,6 +228,7 @@ template<int DIM, class TYPE>
 void NodeData<DIM,TYPE>::packStream(tbox::AbstractStream& stream,
                                     const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::NodeData::packStream()");
    const NodeOverlap<DIM> *t_overlap =
       dynamic_cast<const NodeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -241,6 +243,7 @@ template<int DIM, class TYPE>
 void NodeData<DIM,TYPE>::unpackStream(tbox::AbstractStream& stream,
                                       const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::NodeData::unpackStream()");
    const NodeOverlap<DIM> *t_overlap =
       dynamic_cast<const NodeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/patchdata/outeredge/OuteredgeData.C
+++ b/source/patchdata/outeredge/OuteredgeData.C
@@ -24,6 +24,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 
 
 #define PDAT_OUTEREDGEDATA_VERSION 1
@@ -480,6 +481,7 @@ void OuteredgeData<DIM,TYPE>::packStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuteredgeData::packStream()");
    const EdgeOverlap<DIM> *t_overlap =
       dynamic_cast<const EdgeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -535,6 +537,7 @@ void OuteredgeData<DIM,TYPE>::unpackStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuteredgeData::unpackStream()");
    const EdgeOverlap<DIM> *t_overlap =
       dynamic_cast<const EdgeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -594,6 +597,7 @@ void OuteredgeData<DIM,TYPE>::unpackStreamAndSum(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuteredgeData::unpackStreamAndSum()");
    const EdgeOverlap<DIM> *t_overlap =
       dynamic_cast<const EdgeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/patchdata/outerface/OuterfaceData.C
+++ b/source/patchdata/outerface/OuterfaceData.C
@@ -20,6 +20,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 
 #define PDAT_OUTERFACEDATA_VERSION 1
 
@@ -290,6 +291,7 @@ void OuterfaceData<DIM,TYPE>::packStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuterfaceData::packStream()");
    const FaceOverlap<DIM> *t_overlap = 
       dynamic_cast<const FaceOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -325,6 +327,7 @@ void OuterfaceData<DIM,TYPE>::unpackStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuterfaceData::unpackStream()");
    const FaceOverlap<DIM> *t_overlap =
       dynamic_cast<const FaceOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/patchdata/outernode/OuternodeData.C
+++ b/source/patchdata/outernode/OuternodeData.C
@@ -20,6 +20,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 
 #define PDAT_OUTERNODEDATA_VERSION 1
 
@@ -394,6 +395,7 @@ void OuternodeData<DIM,TYPE>::packStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuternodeData::packStream()");
    const NodeOverlap<DIM> *t_overlap =
       dynamic_cast<const NodeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -424,6 +426,7 @@ void OuternodeData<DIM,TYPE>::unpackStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuternodeData::unpackStream()");
    const NodeOverlap<DIM> *t_overlap =
       dynamic_cast<const NodeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -459,6 +462,7 @@ void OuternodeData<DIM,TYPE>::unpackStreamAndSum(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OuternodeData::unpackStreamAndSum()");
    const NodeOverlap<DIM> *t_overlap =
       dynamic_cast<const NodeOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/patchdata/outerside/OutersideData.C
+++ b/source/patchdata/outerside/OutersideData.C
@@ -20,6 +20,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 #include <stdio.h>
 
 #define PDAT_OUTERSIDEDATA_VERSION 1
@@ -280,6 +281,7 @@ void OutersideData<DIM,TYPE>::packStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OutersideData::packStream()");
    const SideOverlap<DIM> *t_overlap =
       dynamic_cast<const SideOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -307,6 +309,7 @@ void OutersideData<DIM,TYPE>::unpackStream(
    tbox::AbstractStream& stream,
    const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::OutersideData::unpackStream()");
    const SideOverlap<DIM> *t_overlap =
       dynamic_cast<const SideOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/patchdata/side/SideData.C
+++ b/source/patchdata/side/SideData.C
@@ -19,6 +19,7 @@
 #include "tbox/Arena.h"
 #include "tbox/ArenaManager.h"
 #include "tbox/Utilities.h"
+#include "tbox/TimerManager.h"
 
 #define PDAT_SIDEDATA_VERSION 1
 
@@ -280,6 +281,7 @@ template<int DIM, class TYPE>
 void SideData<DIM,TYPE>::packStream(tbox::AbstractStream& stream,
                                     const hier::BoxOverlap<DIM>& overlap) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::SideData::packStream()");
    const SideOverlap<DIM> *t_overlap =
       dynamic_cast<const SideOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS
@@ -301,6 +303,7 @@ template<int DIM, class TYPE>
 void SideData<DIM,TYPE>::unpackStream(tbox::AbstractStream& stream,
                                       const hier::BoxOverlap<DIM>& overlap)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("pdat::SideData::unpackStream()");
    const SideOverlap<DIM> *t_overlap
       =dynamic_cast<const SideOverlap<DIM> *>(&overlap);
 #ifdef DEBUG_CHECK_ASSERTIONS

--- a/source/transfer/datamovers/standard/CoarsenCopyTransaction.C
+++ b/source/transfer/datamovers/standard/CoarsenCopyTransaction.C
@@ -16,6 +16,7 @@
 #include "PatchData.h"
 #include "tbox/SAMRAI_MPI.h"
 #include "CoarsenClasses.h"
+#include "tbox/TimerManager.h"
 
 namespace SAMRAI {
     namespace xfer {
@@ -154,6 +155,7 @@ template<int DIM> int CoarsenCopyTransaction<DIM>::getDestinationProcessor()
 
 template<int DIM> void CoarsenCopyTransaction<DIM>::packStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::CoarsenCopyTransaction::packStream()");
    d_src_level->getPatch(d_src_patch)
               ->getPatchData(s_coarsen_items[d_coarsen_item_id]->
                              d_src)
@@ -162,6 +164,7 @@ template<int DIM> void CoarsenCopyTransaction<DIM>::packStream(tbox::AbstractStr
 
 template<int DIM> void CoarsenCopyTransaction<DIM>::unpackStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::CoarsenCopyTransaction::unpackStream()");
    d_dst_level->getPatch(d_dst_patch)
               ->getPatchData(s_coarsen_items[d_coarsen_item_id]->
                              d_dst)
@@ -170,6 +173,7 @@ template<int DIM> void CoarsenCopyTransaction<DIM>::unpackStream(tbox::AbstractS
 
 template<int DIM> void CoarsenCopyTransaction<DIM>::copyLocalData()
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::CoarsenCopyTransaction::copyLocalData()");
    d_dst_level->getPatch(d_dst_patch)
               ->getPatchData(s_coarsen_items[d_coarsen_item_id]->
                              d_dst)

--- a/source/transfer/datamovers/standard/RefineCopyTransaction.C
+++ b/source/transfer/datamovers/standard/RefineCopyTransaction.C
@@ -15,6 +15,7 @@
 #include "Patch.h"
 #include "PatchData.h"
 #include "tbox/SAMRAI_MPI.h"
+#include "tbox/TimerManager.h"
 
 namespace SAMRAI {
     namespace xfer {
@@ -153,6 +154,7 @@ template<int DIM> int RefineCopyTransaction<DIM>::getDestinationProcessor()
 
 template<int DIM> void RefineCopyTransaction<DIM>::packStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineCopyTransaction::packStream()");
    d_src_level->getPatch(d_src_patch)
               ->getPatchData(s_refine_items[d_refine_item_id]->
                              d_src)
@@ -161,6 +163,7 @@ template<int DIM> void RefineCopyTransaction<DIM>::packStream(tbox::AbstractStre
 
 template<int DIM> void RefineCopyTransaction<DIM>::unpackStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineCopyTransaction::unpackStream()");
    d_dst_level->getPatch(d_dst_patch)
               ->getPatchData(s_refine_items[d_refine_item_id]->
                              d_scratch)
@@ -169,6 +172,7 @@ template<int DIM> void RefineCopyTransaction<DIM>::unpackStream(tbox::AbstractSt
 
 template<int DIM> void RefineCopyTransaction<DIM>::copyLocalData()
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineCopyTransaction::copyLocalData()");
    d_dst_level->getPatch(d_dst_patch)
               ->getPatchData(s_refine_items[d_refine_item_id]->
                              d_scratch)

--- a/source/transfer/datamovers/standard/RefineSchedule.C
+++ b/source/transfer/datamovers/standard/RefineSchedule.C
@@ -2282,7 +2282,7 @@ void RefineSchedule<DIM>::initializeTimers()
       t_fill_data =tbox::TimerManager::getManager() ->
          getTimer("xfer::RefineSchedule::fillData()");
       t_recursive_fill = tbox::TimerManager::getManager() ->
-         getTimer("xfer::RefineSchedule::recursive_fill");
+         getTimer("xfer::RefineSchedule::recursiveFill()");
       t_refine_scratch_data = tbox::TimerManager::getManager() ->
          getTimer("xfer::RefineSchedule::refineScratchData()");
       t_gen_sched_n_squared = tbox::TimerManager::getManager()->

--- a/source/transfer/datamovers/standard/RefineSchedule.C
+++ b/source/transfer/datamovers/standard/RefineSchedule.C
@@ -904,7 +904,10 @@ template<int DIM> void RefineSchedule<DIM>::recursiveFill(
     * cells and interiors of the scratch space on the destination level
     * for data where coarse data takes priority on level boundaries.
     */
-   d_coarse_priority_level_schedule->communicate();
+   {
+      SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineSchedule::recursiveFill()[fill_coarse_schedule]");
+      d_coarse_priority_level_schedule->communicate();
+   }
 
    /*
     * If there is a coarser schedule stored in this object, then we will
@@ -947,7 +950,10 @@ template<int DIM> void RefineSchedule<DIM>::recursiveFill(
     * cells and interiors of the scratch space on the destination level
     * for data where fine data takes priority on level boundaries.
     */
-   d_fine_priority_level_schedule->communicate();
+   {
+      SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineSchedule::recursiveFill()[fill_fine_schedule]");
+      d_fine_priority_level_schedule->communicate();
+   }
 
    /*
     * Fill the physical boundaries of the scratch space on the destination
@@ -971,6 +977,7 @@ template<int DIM> void RefineSchedule<DIM>::fillPhysicalBoundaries(
    tbox::Pointer< hier::PatchLevel<DIM> > level,
    double fill_time) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineSchedule::fillPhysicalBoundaries()");
 #ifdef DEBUG_CHECK_ASSERTIONS
    TBOX_ASSERT(!level.isNull());
 #endif
@@ -1005,6 +1012,7 @@ template<int DIM> void RefineSchedule<DIM>::allocateScratchSpace(
    double fill_time,
    hier::ComponentSelector& allocate_vector) const
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineSchedule::allocateScratchSpace()");
 #ifdef DEBUG_CHECK_ASSERTIONS
    TBOX_ASSERT(!level.isNull());
 #endif

--- a/source/transfer/datamovers/standard/RefineTimeTransaction.C
+++ b/source/transfer/datamovers/standard/RefineTimeTransaction.C
@@ -20,6 +20,7 @@
 #include "tbox/SAMRAI_MPI.h"
 #include "tbox/Utilities.h"
 #include "tbox/MathUtilities.h"
+#include "tbox/TimerManager.h"
 
 namespace SAMRAI {
     namespace xfer {
@@ -168,6 +169,7 @@ template<int DIM> int RefineTimeTransaction<DIM>::getDestinationProcessor()
 
 template<int DIM> void RefineTimeTransaction<DIM>::packStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineTimeTransaction::packStream()");
    const tbox::Pointer< hier::Patch<DIM> >& patch = d_src_level->getPatch(d_src_patch);
 
    tbox::Pointer< hier::PatchData<DIM> > temp =
@@ -187,6 +189,7 @@ template<int DIM> void RefineTimeTransaction<DIM>::packStream(tbox::AbstractStre
 
 template<int DIM> void RefineTimeTransaction<DIM>::unpackStream(tbox::AbstractStream& stream)
 {
+   SAMRAI_SETUP_TIMER_AND_SCOPE("xfer::RefineTimeTransaction::unpackStream()");
    d_dst_level->getPatch(d_dst_patch)
               ->getPatchData(s_refine_items[d_refine_item_id]->
                              d_scratch)


### PR DESCRIPTION
This makes it easier to find performance problems without using, e.g., hpc-toolkit or vtune.